### PR TITLE
Issue #14113 reinstate free text search fallback

### DIFF
--- a/Programming/bundle/nlparser/src/main/webapp/jsp/tabs.jsp
+++ b/Programming/bundle/nlparser/src/main/webapp/jsp/tabs.jsp
@@ -26,7 +26,7 @@
                 <h2 id="MainTitle">${domainEntry.key} Demo</h2>
 
                 <p class="description">${descriptions[domainEntry.key]}</p>
-                <form id="search-form-${domainEntry.key}">
+                <form id="search-form-${domainEntry.key}" class="search-form">
 
                     <button type="button" class="speechButton" id="button-${domainEntry.key}" onclick="startButton('${domainEntry.key}')" style="border: 0; background: transparent">
                         <img src="/static/micon.jpg" alt="speak" id="buttonImage-${domainEntry.key}">                   
@@ -34,6 +34,7 @@
 
                     <input id="search-input-${domainEntry.key}" name="q" type="text" class="input-large search-input"  
                            placeholder="Type your question.." data-searchdomain="${domainEntry.key}"></input>
+                    <input type="submit" style="position: absolute; left: -9999px"/>
 
                     <button type="button" class="clearButton" id="clear-${domainEntry.key}" value="" onclick="clearButton()" style="border: 0; background: transparent">
                         <img src="/static/clear.jpg" alt="clear" id="clearImage-${domainEntry.key}">                   

--- a/Programming/bundle/nlparser/src/main/webapp/static/script.js
+++ b/Programming/bundle/nlparser/src/main/webapp/static/script.js
@@ -119,6 +119,13 @@ $(function () {
             $(this).data("searchdomain"));
     });
     
+    $(".search-form").submit(function (event) {
+        doSearch(
+                $('#search-input-' + currentDomain).closest("form").serialize(),
+                $('#search-input-' + currentDomain).data("searchdomain"));
+        event.preventDefault();
+    });
+    
     function getDocsWithDocPath(data,docpath) {
         var elem = data;
         


### PR DESCRIPTION
A bit hacky on the HTML/JS side, the idea is to create an invisible "Submit" button and override the default submit behaviour. 

I've also included some code reformatting because I'M HORRIBLE and hit Ctrl+Shift+F all the time. Fortunately enough, there isn't much of that, just some spaces. Should be in a separate commit, I know - slipped my mind :(

EDIT: How it works: you type in something that doesn't match the grammar (say, "lucie") and hit Enter, which submits the form.
